### PR TITLE
build.xml will export the FRamework files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -118,4 +118,28 @@
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>
+
+  <target name="jar" depends="compile">
+    <echo>[athena-jar] Making jar ${dist.jar}.</echo>
+    <mkdir dir="${dist.dir}" />
+    <mkdir dir="${build.jars}" />
+
+    <echo>[athena-jar] Copying jars to ${build.jars}.</echo>
+    <copy todir="${build.jars}" flatten="true">
+      <path refid="classpath.path"/>
+    </copy>
+
+    <jar destfile="${dist.jar}" update="false">
+      <manifest>
+        <attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
+        <attribute name="Robot-Class" value="${robot.class}"/>
+        <attribute name="Class-Path" value="."/>
+      </manifest>
+
+      <fileset dir="${build.dir}" includes="**/*.class"/>
+      <fileset dir="FRamework/build" includes="**/*.class"/>
+      <zipgroupfileset dir="${build.jars}"/>
+    </jar>
+  </target>
+
 </project>


### PR DESCRIPTION
This just fixes build.xml so "deploy" includes FRamework library classes when it makes the jar!